### PR TITLE
Segmentation Fault With Sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,9 +62,8 @@ gem "font-awesome-sass", "~> 6.1"
 gem "simple_form", github: "heartcombo/simple_form"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
-
 end
 
 group :development do
@@ -86,4 +85,3 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
-gem "sassc-rails"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,6 +7,13 @@ Rails.application.config.assets.version = "1.0"
 # Rails.application.config.assets.paths << Emoji.images_path
 
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
+
+# Désactivez la compilation concurrente des assets pour résoudre le problème de segmentation sassc.
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end
+
+
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.


### PR DESCRIPTION
**Erreur lors de la tentative d'accès à l'application dans le nagateur:** 
`/home/marionrbt/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sassc-2.4.0/lib/sassc/engine.rb:43: [BUG] Segmentation fault at 0x0000000000000000`


**Solution : Désactiver la compilation concurrente des assets**
Fichier config/initializers/assets.rb 
`# Désactivez la compilation concurrente des assets pour résoudre le problème de segmentation sassc.
Rails.application.config.assets.configure do |env|
  env.export_concurrent = false
end`